### PR TITLE
Bump org.sonarqube from 4.3.0.3225 to 4.4.0.3356 (#904)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id "com.diffplug.spotless" version "6.21.0"
-    id "org.sonarqube" version "4.3.0.3225"
+    id "org.sonarqube" version "4.4.0.3356"
     id "name.remal.sonarlint" version "3.3.0"
 }
 


### PR DESCRIPTION
Bumps org.sonarqube from 4.3.0.3225 to 4.4.0.3356.

---
updated-dependencies:
- dependency-name: org.sonarqube dependency-type: direct:production update-type: version-update:semver-minor ...